### PR TITLE
replace AV_CODEC_CAP_AUTO_THREADS

### DIFF
--- a/source/blender/blenkernel/intern/writeffmpeg.c
+++ b/source/blender/blenkernel/intern/writeffmpeg.c
@@ -855,7 +855,7 @@ static AVStream *alloc_video_stream(FFMpegContext *context,
                                                             255);
   st->avg_frame_rate = av_inv_q(c->time_base);
 
-  if (codec->capabilities & AV_CODEC_CAP_AUTO_THREADS) {
+  if (codec->capabilities & AV_CODEC_CAP_OTHER_THREADS) {
     c->thread_count = 0;
   }
   else {

--- a/source/blender/imbuf/intern/anim_movie.c
+++ b/source/blender/imbuf/intern/anim_movie.c
@@ -554,7 +554,7 @@ static int startffmpeg(struct anim *anim)
   avcodec_parameters_to_context(pCodecCtx, video_stream->codecpar);
   pCodecCtx->workaround_bugs = FF_BUG_AUTODETECT;
 
-  if (pCodec->capabilities & AV_CODEC_CAP_AUTO_THREADS) {
+  if (pCodec->capabilities & AV_CODEC_CAP_OTHER_THREADS) {
     pCodecCtx->thread_count = 0;
   }
   else {

--- a/source/blender/imbuf/intern/indexer.c
+++ b/source/blender/imbuf/intern/indexer.c
@@ -559,7 +559,7 @@ static struct proxy_output_ctx *alloc_proxy_output_ffmpeg(
   av_dict_set(&codec_opts, "preset", "veryfast", 0);
   av_dict_set(&codec_opts, "tune", "fastdecode", 0);
 
-  if (rv->codec->capabilities & AV_CODEC_CAP_AUTO_THREADS) {
+  if (rv->codec->capabilities & AV_CODEC_CAP_OTHER_THREADS) {
     rv->c->thread_count = 0;
   }
   else {
@@ -872,7 +872,7 @@ static IndexBuildContext *index_ffmpeg_create_context(struct anim *anim,
   avcodec_parameters_to_context(context->iCodecCtx, context->iStream->codecpar);
   context->iCodecCtx->workaround_bugs = FF_BUG_AUTODETECT;
 
-  if (context->iCodec->capabilities & AV_CODEC_CAP_AUTO_THREADS) {
+  if (context->iCodec->capabilities & AV_CODEC_CAP_OTHER_THREADS) {
     context->iCodecCtx->thread_count = 0;
   }
   else {


### PR DESCRIPTION
AV_CODEC_CAP_AUTO_THREADS is deprecated and replaced with AV_CODEC_CAP_OTHER_THREADS